### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run the audit from a Ruby application like so
     $ irb
     > require 'access_lint'
     => true
-    > Audit.new('http://twitter.com').run
+    > AccessLint::Audit.new('http://twitter.com').run
     => results ...
 
 ### Results Object


### PR DESCRIPTION
Unless we `include AccessLint`, we need to call Audit.new using its full name including the module.
