### PR TITLE
defines AccessLint::RunnerError

### DIFF
--- a/lib/access_lint.rb
+++ b/lib/access_lint.rb
@@ -7,4 +7,5 @@ module AccessLint
   class Error < StandardError; end
   class AuditError < Error; end
   class ParserError < Error; end
+  class RunnerError < Error; end
 end


### PR DESCRIPTION
Hello!

This error class is used in the code, but it wasn't defined. Now it is. 