### PR TITLE
Add JSON as output option

### DIFF
--- a/lib/access_lint/cli.rb
+++ b/lib/access_lint/cli.rb
@@ -7,38 +7,44 @@ module AccessLint
     include CommandLineReporter
 
     desc 'audit', 'audit TARGET'
+    option :output
     def audit(target)
       exit_code = 0
 
-      report(message: "auditing #{target}", color: "blue") do
-        results = Audit.new(target).run
+      if options[:output] == 'json'
+        puts Audit.new(target).run if options[:output] == 'json'
+      else
 
-        results.each do |group|
-          section = group[0]
+        report(message: "auditing #{target}", color: "blue") do
+          results = Audit.new(target).run
 
-          case section
-          when "NA"
-            color = :blue
-          when "PASS"
-            color = :green
-          when "FAIL"
-            color = :red
-          end
+          results.each do |group|
+            section = group[0]
 
-          group[1].each do |rule|
-            name = rule.fetch("title")
-            severity = rule.fetch("severity")
-            elements = rule.fetch("element_names")
-
-            puts
-            aligned("#{section} - #{name} (#{severity})", color: color)
-
-            elements.each do |element|
-              aligned("* #{element[0..80]}...")
+            case section
+            when "NA"
+              color = :blue
+            when "PASS"
+              color = :green
+            when "FAIL"
+              color = :red
             end
 
-            if section == "FAIL" && elements.any?
-              exit_code = 1
+            group[1].each do |rule|
+              name = rule.fetch("title")
+              severity = rule.fetch("severity")
+              elements = rule.fetch("element_names")
+
+              puts
+              aligned("#{section} - #{name} (#{severity})", color: color)
+
+              elements.each do |element|
+                aligned("* #{element[0..80]}...")
+              end
+
+              if section == "FAIL" && elements.any?
+                exit_code = 1
+              end
             end
           end
         end

--- a/lib/access_lint/cli.rb
+++ b/lib/access_lint/cli.rb
@@ -12,7 +12,7 @@ module AccessLint
       exit_code = 0
 
       if options[:output] == 'json'
-        puts Audit.new(target).run if options[:output] == 'json'
+        puts Audit.new(target).run.to_json if options[:output] == 'json'
       else
 
         report(message: "auditing #{target}", color: "blue") do

--- a/vendor/access-lint/bin/auditor.js
+++ b/vendor/access-lint/bin/auditor.js
@@ -45,7 +45,9 @@ if (system.args.length !== 2) {
             title: raw_results[i]['rule']['heading'],
             severity: raw_results[i]['rule']['severity'],
             element_names: element_names,
-            elements: raw_results[i]['elements']
+            elements: raw_results[i]['elements'],
+            code: raw_results[i]['rule']['code'],
+            url: raw_results[i]['rule']['url']
           });
         }
 


### PR DESCRIPTION
In some circumstances I want to get JSON output so I can parse it with other tools. This adds the ability to do `access_lint audit http://google.com --output json` It's not the best way to do this but it does what I need for right now. 
