### PR TITLE
Fix for SSL errors

### DIFF
--- a/lib/access_lint/runner.rb
+++ b/lib/access_lint/runner.rb
@@ -8,7 +8,7 @@ module AccessLint
     end
 
     def run
-      @output = `phantomjs #{RUNNER_PATH} #{@target}`
+      @output = `phantomjs --ignore-ssl-errors=yes #{RUNNER_PATH} #{@target}`
       return if audit_success?
 
       if !phantomjs_installed?


### PR DESCRIPTION
Hi again-

Not sure if this is desired on your part, but I've been having issues with sites with certificates that phantomjs does not like:

```
2015-12-13T20:29:24 [DEBUG] Network - SSL Error: "The issuer certificate of a locally looked up certificate could not be found"
2015-12-13T20:29:24 [DEBUG] Network - SSL Error: "No certificates could be verified"
2015-12-13T20:29:24 [DEBUG] Network - Resource request error: 6 ( "SSL handshake failed" )
```

What is strange is that this does not seem to be consistent- one machine I have on ubuntu 12.04 does not throw these while a 15.04 does. 

At any rate, this fixes the situation.
